### PR TITLE
Update Debian packages during image build

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -10,12 +10,11 @@ ENV USER_ID="99" \
     DEBIAN_FRONTEND="noninteractive" \
     PYTHONUNBUFFERED="1"
 
-# --- System minimal & Base-Paket-Fixes ---
+# --- System minimal & Debian security updates ---
 RUN set -eux; \
     apt-get update; \
+    apt-get -y upgrade; \
     apt-get install -y --no-install-recommends git ca-certificates tzdata; \
-    # Base-Image CVEs (z. B. expat) schneller bekommen:
-    apt-get install -y --no-install-recommends --only-upgrade libexpat1 || true; \
     rm -rf /var/lib/apt/lists/*
 
 # --- venv + Requirements mit Patch-Ranges (autopatch bei jedem Build) ---

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -11,8 +11,8 @@ ENV USER_ID="99" \
 
 RUN set -eux; \
     apt-get update; \
+    apt-get -y upgrade; \
     apt-get install -y --no-install-recommends git ca-certificates tzdata libffi8; \
-    apt-get install -y --no-install-recommends --only-upgrade libexpat1 || true; \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -11,8 +11,8 @@ ENV USER_ID="99" \
 
 RUN set -eux; \
     apt-get update; \
+    apt-get -y upgrade; \
     apt-get install -y --no-install-recommends git ca-certificates tzdata; \
-    apt-get install -y --no-install-recommends --only-upgrade libexpat1 || true; \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt


### PR DESCRIPTION
Updates the architecture-specific Dockerfiles so Debian packages are upgraded during image build before installing the runtime packages.

This should include current Debian security fixes in rebuilt images, especially for base packages such as OpenSSL.

Changed files:
- Dockerfile.amd64
- Dockerfile.arm64v8
- Dockerfile.arm32v7